### PR TITLE
add Voltage Park ($2.25 H100 SXM5's)

### DIFF
--- a/cloud_gpu.json
+++ b/cloud_gpu.json
@@ -1052,6 +1052,38 @@
             "persistence": true,
             "region": "US",
             "pricing-source": "https://puregpu.com"
+        },
+	{
+            "name": "Voltage Park",
+            "url": "https://www.voltagepark.com/",
+            "cost1080": "-",
+            "costv100": "-",
+            "costp100": "-",
+            "costt4": "-",
+            "costk80": "-",
+            "costm60": "-",
+            "cost3080": "-",
+            "cost3090": "-",
+            "costp4": "-",
+            "cost2080": "-",
+            "costa5000": "-",
+            "costa6000": "-",
+            "costa100_40": "-",
+            "costa100_80": "-",
+            "costrtx6000": "-",
+            "costa40": "-",
+            "costa10": "-",
+            "cost4090": "-",
+            "costh100": "$2.25",
+            "costl40": "-",
+            "costl40s": "-",
+            "images": true,
+            "notebooks": true,
+            "ssh": true,
+            "credits": "$25",
+            "persistence": true,
+            "region": "US",
+            "pricing-source": "https://dashboard.voltagepark.com/order/configure-deployment"
         }
     ]
 }


### PR DESCRIPTION
Hi! 

Jonathan from Voltage Park here. We just launched H100 SXM5's (not PCIEs) for $2.25/hr, lowest in the industry. Would love to share this with the Cloud GPUs community -- with $25 in free credits granted upon signup!

Thanks!